### PR TITLE
fix: 修改镜像配额时镜像的body没有用quotas包一层

### DIFF
--- a/src/main/java/com/yunionyun/mcp/mcclient/managers/impl/ImageQuotaManager.java
+++ b/src/main/java/com/yunionyun/mcp/mcclient/managers/impl/ImageQuotaManager.java
@@ -49,8 +49,13 @@ public class ImageQuotaManager extends GlanceManager
         return quotaSet(s, type, id, body);
     }
     
-    private JSONObject quotaSet(Session s, String type, String id, JSONObject body) throws McClientJavaBizException, IOException, JSONClientException
+    private JSONObject quotaSet(Session s, String type, String id, JSONObject params) throws McClientJavaBizException, IOException, JSONClientException
     {
+        if (params == null)
+        {
+            return null;
+        }
+        
         StringBuilder url = new StringBuilder();
         url.append("/");
         url.append(this.keywordPlural);
@@ -59,10 +64,13 @@ public class ImageQuotaManager extends GlanceManager
         url.append("/");
         url.append(id);
         
-        if ("domains".equals(type) && !body.containsKey("domain"))
+        if ("domains".equals(type) && !params.containsKey("domain"))
         {
-            body.put("domain", id);
+            params.put("domain", id);
         }
+        
+        JSONObject body = new JSONObject();
+        body.put(keywordPlural, params);
         
         return this._post(s, url.toString(), body, this.keywordPlural);
     }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题:**
修改镜像配额时镜像的body没有用quotas包一层，导致修改失败

**是否需要 backport 到之前的 release 分支:**
release/2.10.0

/cc @swordqiu